### PR TITLE
implemented singleton design pattern on data sources

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -49,4 +49,4 @@ def data_source(source):
     :rtype: LocationService
     """
     storedSources = DataSourceSingleton()
-    return storedSources._DATA_SOURCES.get(source.lower())
+    return (storedSources.get_data_sources).get(source.lower())

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -34,6 +34,12 @@ class DataSourceSingleton:
             }
         return DataSourceSingleton._instance
 
+    def get_data_sources(self):
+        """
+        retrieves and returns _DATA_SOURCES dictionary 
+        """
+        return self._DATA_SOURCES
+
 
 def data_source(source):
     """

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -5,6 +5,10 @@ from ..services.location.nyt import NYTLocationService
 
 
 class DataSourceSingleton:
+    """
+    Singleton class used for storing and retrieving Data Sources
+    """
+
     # variable storing the ONLY (if any) DataSourceSingle instance
     _instance = None
 

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -3,12 +3,24 @@ from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
-# Mapping of services to data-sources.
-DATA_SOURCES = {
-    "jhu": JhuLocationService(),
-    "csbs": CSBSLocationService(),
-    "nyt": NYTLocationService(),
-}
+
+class DataSourceSingleton:
+    _instance = None
+
+    def __new__(self):
+        # creates new DataSourceSingleton instance iff one does not exist.
+        # Then returns the new/existing instance
+        if not DataSourceSingleton._instance:
+            DataSourceSingleton._instance = super(
+                DataSourceSingleton, self).__new__(self)
+
+            # Mapping of services to data-sources.
+            self._DATA_SOURCES = {
+                "jhu": JhuLocationService(),
+                "csbs": CSBSLocationService(),
+                "nyt": NYTLocationService(),
+            }
+        return DataSourceSingleton._instance
 
 
 def data_source(source):
@@ -18,4 +30,5 @@ def data_source(source):
     :returns: The service.
     :rtype: LocationService
     """
-    return DATA_SOURCES.get(source.lower())
+    storedSources = DataSourceSingleton()
+    return storedSources._DATA_SOURCES.get(source.lower())

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -5,11 +5,19 @@ from ..services.location.nyt import NYTLocationService
 
 
 class DataSourceSingleton:
+    # variable storing the ONLY (if any) DataSourceSingle instance
     _instance = None
 
     def __new__(self):
-        # creates new DataSourceSingleton instance iff one does not exist.
-        # Then returns the new/existing instance
+        """
+        Creates new DataSourceSingleton instance iff one does not exist.
+        Otherwise, existing instance is used.
+        Then returns the new/existing instance.
+
+        :returns: new/existing instance of DataSourceSingleton object.
+        :rtype: DataSourceSingleton
+        """
+
         if not DataSourceSingleton._instance:
             DataSourceSingleton._instance = super(
                 DataSourceSingleton, self).__new__(self)

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -3,7 +3,7 @@ import enum
 
 from fastapi import APIRouter, HTTPException, Request
 
-from ..data import DATA_SOURCES
+from ..data import DataSourceSingleton
 from ..models import LatestResponse, LocationResponse, LocationsResponse
 
 V2 = APIRouter()
@@ -107,4 +107,5 @@ async def sources():
     """
     Retrieves a list of data-sources that are availble to use.
     """
-    return {"sources": list(DATA_SOURCES.keys())}
+    storedSources = DataSourceSingleton()
+    return {"sources": list(storedSources._DATA_SOURCES.keys())}

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -108,4 +108,4 @@ async def sources():
     Retrieves a list of data-sources that are availble to use.
     """
     storedSources = DataSourceSingleton()
-    return {"sources": list(storedSources._DATA_SOURCES.keys())}
+    return {"sources": list((storedSources.get_data_sources()).keys())}


### PR DESCRIPTION
Added a singleton design pattern into __init__.py where the data sources are accessed from. 
This allows for us to make the sources private and have only one instance of the singleton object.

Also updated v2.py to now work with accessing data sources from singleton.